### PR TITLE
Rewrite TistoryError, the TistoryResponse wrapper and TistoryRequest

### DIFF
--- a/tistory/__init__.py
+++ b/tistory/__init__.py
@@ -4,7 +4,7 @@ import json
 import os
 from shlex import quote as shlex_quote
 
-from tistory.api import Tistory
+from tistory.api import Tistory, TistoryError
 from tistory.auth import TistoryOAuth2
 
 def load_config(fname):


### PR DESCRIPTION
TistoryError now has attributes for status_code, error_message and error_type
_error_handler() was moved from TistoryResponse to TistoryError.
_error_handler() will now return 'unknown' if the message isn't known.

The API URL creation is moved from TistoryClassCall to TistoryRequest.
It's now possible to access the uriparts attribute in the TistoryResponse
object.

Removed the TistoryAPI class and moved the API_URL template to
TistoryRequest

TistoryRequest.req was renamed to TistoryRequest.request
TistoryRequest.bytes was renamed to TistoryRequest.content to reflect
the name in requests.response

Various documentation rewrites.
